### PR TITLE
Add pyproject-fmt and pin all dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,9 @@
 repos:
+  - repo: https://github.com/tox-dev/pyproject-fmt
+    rev: v2.9.0
+    hooks:
+      - id: pyproject-fmt
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.2
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,34 +1,34 @@
 [build-system]
-requires = ["hatchling"]
 build-backend = "hatchling.build"
+requires = [ "hatchling" ]
 
 [project]
 name = "sqlfluff-tstring"
 version = "0.1.0"
 description = "Auto-format SQL inside Python t-strings using sqlfluff"
 requires-python = ">=3.14"
-dependencies = ["sqlfluff"]
+classifiers = [ "Programming Language :: Python :: 3 :: Only", "Programming Language :: Python :: 3.14" ]
+dependencies = [ "sqlfluff>=4.0.4" ]
 
-[project.scripts]
-sqlfluff-tstring = "sqlfluff_tstring.cli:main"
+scripts.sqlfluff-tstring = "sqlfluff_tstring.cli:main"
+
+[dependency-groups]
+dev = [
+  "pre-commit>=4.5.1",
+  "pytest>=9.0.2",
+  "ruff>=0.15.5",
+  "syrupy>=5.1",
+  "ty>=0.0.21",
+]
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/sqlfluff_tstring"]
+packages = [ "src/sqlfluff_tstring" ]
 
 [tool.uv]
 required-version = ">=0.10.7"
 
 [tool.ruff]
-extend-exclude = ["tests/fixtures"]
+extend-exclude = [ "tests/fixtures" ]
 
 [tool.ty.src]
-exclude = ["tests/fixtures"]
-
-[dependency-groups]
-dev = [
-    "pre-commit>=4.5.1",
-    "pytest",
-    "ruff",
-    "syrupy",
-    "ty",
-]
+exclude = [ "tests/fixtures" ]


### PR DESCRIPTION
pyproject-fmt enforces consistent formatting and section ordering in pyproject.toml. All runtime and dev dependencies now have minimum version pins matching currently installed versions to prevent unexpected breakage from older versions.