### PR TITLE
Switch build backend from hatchling to uv_build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-build-backend = "hatchling.build"
-requires = [ "hatchling" ]
+build-backend = "uv_build"
+requires = [ "uv-build>=0.7.5,<0.8" ]
 
 [project]
 name = "sqlfluff-tstring"
@@ -21,11 +21,11 @@ dev = [
   "ty>=0.0.21",
 ]
 
-[tool.hatch.build.targets.wheel]
-packages = [ "src/sqlfluff_tstring" ]
-
 [tool.uv]
 required-version = ">=0.10.7"
+
+[tool.uv.build-backend]
+module-name = "sqlfluff_tstring"
 
 [tool.ruff]
 extend-exclude = [ "tests/fixtures" ]

--- a/uv.lock
+++ b/uv.lock
@@ -370,15 +370,15 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "sqlfluff" }]
+requires-dist = [{ name = "sqlfluff", specifier = ">=4.0.4" }]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = ">=4.5.1" },
-    { name = "pytest" },
-    { name = "ruff" },
-    { name = "syrupy" },
-    { name = "ty" },
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "ruff", specifier = ">=0.15.5" },
+    { name = "syrupy", specifier = ">=5.1" },
+    { name = "ty", specifier = ">=0.0.21" },
 ]
 
 [[package]]


### PR DESCRIPTION
This consolidates the toolchain on uv since the project already uses uv for dependency management. The uv_build backend auto-detects the src layout via the module-name setting.